### PR TITLE
Update consentBaseUrl as consent.hello.coop is no longer reachable

### DIFF
--- a/src/lib/consent.ts
+++ b/src/lib/consent.ts
@@ -2,7 +2,7 @@ import Cors from 'cors'
 
 import initMiddleware from './init-middleware'
 
-export const consentBaseUrl = new URL('https://consent.hello.coop')
+export const consentBaseUrl = new URL('https://wallet.hello.coop')
 
 export const consentCors = initMiddleware(
     Cors({


### PR DESCRIPTION
consent.hello.coop is no longer reachable, I get DNS_PROBE_FINISHED_NXDOMAIN

Based on 

- https://issuer.hello.coop/.well-known/openid-configuration
- https://github.com/hellocoop/hello.dev/commit/b79f9a1d92a33760f446d35255015ca8193b6454
- https://www.greenfielddemo.com/

It looks like the endpoint changed a few months back and recently got shut down. Updating the endpoint here. Not sure if the SDK should also change all references from 'consent' to 'wallet', but consent makes most sense to me still. 